### PR TITLE
Adds BD Configuration for cataloging repos

### DIFF
--- a/.bd.yml
+++ b/.bd.yml
@@ -1,0 +1,5 @@
+name: httprouterpersist
+team: web
+type: library
+tags:
+  language: go


### PR DESCRIPTION
## Problem
<!-- What are you trying to solve? -->

We would like to catalog repositories and pull meta information such as the team that owns the repo.

## Solution
<!-- How does this change fix the problem? -->

Adds a configuration file specifying basic metadata information this repository.