### PR TITLE
Adds github settings configuration file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/settings.yml  @shopsmart/tech-ops-team

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,35 @@
+repository:
+  name: httprouterpersist
+  description: null
+  homepage: null
+  topics: ''
+  private: false
+  has_issues: true
+  has_projects: true
+  has_wiki: true
+  has_downloads: true
+  default_branch: master
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+teams:
+  - name: developers
+    permission: push
+  - name: tech-ops-team
+    permission: admin
+  - name: web-team
+    permission: admin
+branches:
+  - name: '*-base'
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: {}
+      required_status_checks: null
+      enforce_admins: false
+      required_linear_history: false
+      restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -22,7 +22,7 @@ teams:
   - name: web-team
     permission: admin
 branches:
-  - name: '*-base'
+  - name: master
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 2


### PR DESCRIPTION
## Problem
<!-- What are you trying to solve? -->

We want Github settings to be properly configured across the organization.

## Solution
<!-- How does this solve the problem? -->

The [Settings App](https://github.com/probot/settings) can help us manage our Github settings through code.  Not only will this version our settings, it will enable developers to add configurations by simply putting in a PR.  It can help manage labels for us as well which will come in handy if we want to enable auto versioning via tag labels.  The code owners file will enforce that the Tech Ops Team needs to approve a change to the settings.